### PR TITLE
Update strings.xml

### DIFF
--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -62,7 +62,7 @@
     <string name="alarm_volume_subtext"> Izberi glasnost za budilke.\nGlasnost se zvišuje z leve proti desni.</string>
     <string name="alarms">Budilke</string>
     <string name="alarms_repeats_every">Budilka se ponovi vsak:</string>
-    <string name="all_alarms">Vse budilke</string>
+    <string name="all_alarms">vse budilke</string>
     <string name="allow">Dovoli</string>
     <string name="already_setted">Že nastavljeno!\nPritisni tukaj da spremeniš</string>
     <string name="an_error_has_occurred">Pojavila se je napaka!</string>


### PR DESCRIPTION
The word "vse" is used/linked in the context here: `<string name="uninstall_subtext">`
So when it links it it uses a higher case (big) letter instead of a lowecase. I fixed that, but i hope it isn't used elsewhere, weird thing...

## Purpose
_Describe the problem or feature in addition to a link to the issues._

## Approach
_How does this change address the problem?_

#### Open Questions and Pre-Merge TODOs
- [ ] Use github checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

#### Blog Posts
- [How to Pull Request](https://github.com/flexyford/pull-request) Github Repo with Learning focused Pull Request Template.

