### PR TITLE
Make swedish text for emergency services reflect action

### DIFF
--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -142,7 +142,7 @@
     <string name="left_handed">Vänsterhänt</string>
     <string name="light">Ljus</string>
     <string name="location">Plats</string>
-    <string name="emergency_services">Nödtjänster</string>
+    <string name="emergency_services">Ring Larmcentral</string>
     <string name="mail">Epost</string>
     <string name="maps">Kartor</string>
 


### PR DESCRIPTION
The current text does not convey the intent of making a call to the emergency services. This change conveys that intent more clearly.