### PR TITLE
New Italian translation, and new Debian build HOW-TO

### DIFF
--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright 2019 Uriah Shaul Mandel
+  ~ Contributors:
+  ~   * Dario Mastromattei
+  ~   * Niccolo Rigacci <niccolo@rigacci.org>
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -30,69 +33,65 @@
     <!--For Tests:-->
 
     <string name="about">Informazioni</string>
-    <string name="about_subtext">Ciao!\nIl mio nome è Uriah Shaul Mandel, e s/ ono lo sviluppatore di questa piattaforma.\n
-        Ho\ passato gran parte della mia vita \"adulta\" realizzando questa piattaforma, e l\'ho rilasciata per essere usata gratis da tutti.\nSei più che benvenuto di contattarmi via email:\nbaldphone.contact@gmail.com
-    </string>
+    <string name="about_subtext">Ciao! Il mio nome è Uriah Shaul Mandel e sono lo sviluppatore di questa app.\nHo speso una gran parte della mia vita \"adulta\" per realizzare questo software e l\'ho rilasciato come Open Source affinché tutti lo possano utilizzare liberamente.\nSe vuoi contattarmi vie email, sei il benvenuto:\nbaldphone.contact@gmail.com</string>
     <string name="accessibility_level">Livello di accessibilità</string>
     <string name="accessibility_settings">Accessibilità</string>
     <string name="accidental_touches">Protezione contro i tocchi accidentali</string>
     <string name="accidental_touches_settings_subtext">La protezione dai tocchi accidentali evita che ci siano tocchi indesiderati quando il telefono è
-        coperto\nse riscontri qualche problema puoi disattivarlo
+        coperto.\nSe riscontri qualche problema puoi disattivarlo.
     </string>
-    <string name="accidental_touches_subtext">Un tocco accidentale è stato rilevato\npremi OK per continuare ad usare il telefono\nse
-        questo messaggio continua a comparire puoi disattivarlo dalle impostazioni per l\'accessibilità
+    <string name="accidental_touches_subtext">È stato rilevato un tocco accidentale.\nPremi OK per continuare ad usare il telefono.\nSe
+        questo messaggio continua a comparire puoi disattivarlo dalle impostazioni di accessibilità.
     </string>
     <string name="acknowledgments">Ringraziamenti</string>
     <string name="adaptive">Adattivo</string>
-    <string name="add_alarm">Aggiungi Sveglia</string>
-    <string name="add_alarm_quickly">Aggiungi Timer</string>
-    <string name="add_contact">Aggiungi Contatto</string>
-    <string name="add_emergency_contact">Aggiungi contatto d\'emergenza</string>
-    <string name="add_pill">Aggiungi Pillola</string>
-    <string name="add_shortcut">Aggiungi Scorciatoia</string>
-    <string name="add_to_favorite">Aggiungi ai Favoriti</string>
+    <string name="add_alarm">Aggiungi sveglia</string>
+    <string name="add_alarm_quickly">Aggiungi timer</string>
+    <string name="add_contact">Aggiungi contatto</string>
+    <string name="add_emergency_contact">Aggiungi contatto di emergenza</string>
+    <string name="add_pill">Aggiungi pillola</string>
+    <string name="add_shortcut">Aggiungi scorciatoia</string>
+    <string name="add_to_favorite">Aggiungi ai preferiti</string>
     <string name="add_to_home">Aggiungi alla Home</string>
-    <string name="add_to_sos">Aggiungi ad SOS</string>
+    <string name="add_to_sos">Aggiungi a SOS</string>
     <string name="address">Indirizzo</string>
-    <string name="advanced_options">Opzioni Avanzate</string>
+    <string name="advanced_options">Impostazioni avanzate</string>
     <string name="afternoon">Pomeriggio</string>
-    <string name="airplane_mode">Modalità Aereo</string>
-    <string name="alarm_name">Nome Sveglia</string>
-    <string name="alarm_volume">Volume Sveglia</string>
-    <string name="alarm_volume_subtext">Scegli il Volume per le Sveglie.\nIl volume può essere aumentato da sinistra a destra.</string>
+    <string name="airplane_mode">Modalità aereo</string>
+    <string name="alarm_name">Nome sveglia</string>
+    <string name="alarm_volume">Volume sveglia</string>
+    <string name="alarm_volume_subtext">Imposta il volume per le sveglie.\nAumenta il volume spostando il selettore verso destra.</string>
     <string name="alarms">Sveglie</string>
 
-    <string name="alarms_repeats_every">La sveglia si ripete ogni</string>
-    <string name="all_alarms">Tutte le Sveglie</string>
-    <string name="allow">Permetti</string>
-    <string name="already_setted">Già Impostato!\nPremi qui per Cambiarlo</string>
-    <string name="an_error_has_occurred">C\'è stato un errore!</string>
-    <string name="and_welcome_to_baldphone">e benvenuto al Baldphone</string>
+    <string name="alarms_repeats_every">Si ripete ogni</string>
+    <string name="all_alarms">tutte le sveglie</string>
+    <string name="allow">Constenti</string>
+    <string name="already_setted">Tastiera impostata.\nTocca qui per cambiare.</string>
+    <string name="an_error_has_occurred">Si è verificato un errore!</string>
+    <string name="and_welcome_to_baldphone">benvenuto in BaldPhone!</string>
 
     <string name="apps">Applicazioni</string>
-    <string name="are_you_sure_you_want_to_delete___">Sei sicuro che vuoi cancellare %s?</string>
+    <string name="are_you_sure_you_want_to_delete___">Sei sicuro di voler eliminare %s?</string>
     <string name="assistant">Assistente</string>
     <string name="at_least_one_day_must_be_selected">Devi selezionare almeno un giorno!</string>
-    <string name="auto_brightness">Luminosità\nAutomatica</string>
-    <string name="backspace">Cancella</string>
-    <string name="baldphone_bla_allow_permission">Per favore concedi i seguenti permessi:</string>
+    <string name="auto_brightness">Luminosità\nadattiva</string>
+    <string name="backspace">Annulla</string>
+    <string name="baldphone_bla_allow_permission">Sono richieste le seguenti autorizzazioni:</string>
     <string name="blocked">Bloccato</string>
     <string name="bluetooth">Bluetooth</string>
     <string name="brightness">Luminosità</string>
-    <string name="brightness_subtext">Cambia la luminosità.</string>
-    <string name="cache_cleared_successfully">La Cache è stata pulita correttamente!</string>
+    <string name="brightness_subtext">Livello di luminosità.</string>
+    <string name="cache_cleared_successfully">La cache è stata pulita correttamente</string>
     <string name="call">Chiama</string>
-    <string name="calling">In chiamata</string>
+    <string name="calling">Gestione telefonate</string>
 
-    <string name="call_log">Registro chiamate:</string>
-    <string name="call_subtext">Questo permesso è richiesto per permettere la chiamata ai contatti.</string>
-    <string name="camera">Fotocamera</string>
-    <string name="camera_subtext">Questo permesso è richiesto per accendere la torcia.</string>
-    <string name="cancel">Cancella</string>
-    <string name="change_pills_time">Cambia Orario delle Pillole</string>
-    <string name="change_system_settings_subtext">Per cortesia permetti a BaldPhone di cambiare le impostazioni, come aumentare la dimensione dei caratteri
-        e cambiare la luminosità.
-    </string>
+    <string name="call_log">Chiamate recenti</string>
+    <string name="call_subtext">Autorizzazione necessaria per effettuare telefonate.</string>
+    <string name="camera">Fotocamera</string> // Used both as permission and as icon label in the Home page.
+    <string name="camera_subtext">Autorizzazione necessaria per accendere la torcia.</string>
+    <string name="cancel">Annulla</string>
+    <string name="change_pills_time">Modifica orari pillole</string>
+    <string name="change_system_settings_subtext">Per cortesia consenti a BaldPhone di modificare le impostazioni, ad esempio aumentare la dimensione dei caratteri, cambiare la luminosità, ecc.</string>
     <string name="choose_friday">Ven</string>
     <string name="choose_monday">Lun</string>
     <string name="choose_saturday">Sab</string>
@@ -100,77 +99,71 @@
     <string name="choose_thursday">Gio</string>
     <string name="choose_tuesday">Mar</string>
     <string name="choose_wednesday">Mer</string>
-    <string name="clear">Pulisci</string>
-    <string name="clear_cache">Pulisci Cache</string>
-    <string name="clear_data">Elimina Tutti i Dati</string>
-    <string name="clear_data_subtext">Sei sicuro di voler cancellare tutti i dati?</string>
-    <string name="clear_data_subtext2">100%?</string>
-    <string name="clear_data_subtext3">Sicuro?\npremendo sì cancellerai tutti i dati!</string>
+    <string name="clear">Elimina</string>
+    <string name="clear_cache">Pulizia cache</string>
+    <string name="clear_data">Elimina dati</string>
+    <string name="clear_data_subtext">Sei sicuro di voler eliminare tutti i dati? La app tornerà come appena installata.</string>
+    <string name="clear_data_subtext2">Sicuro al 100%?</string>
+    <string name="clear_data_subtext3">Sicuro sicuro?\nToccando Sì eliminerai tutti i dati!</string>
     <string name="clock">Orologio</string>
     <string name="coming_soon">In arrivo prossimamente!</string>
     <string name="connection_settings">Connessione</string>
-    <string name="contact_must_has_name">Il contatto deve avere un Nome!</string>
+    <string name="contact_must_has_name">Il contatto deve avere un nome!</string>
     <string name="contact_not_created">Contatto non creato!</string>
     <string name="contacts">Contatti</string>
-    <string name="contacts_read_subtext">Questo permesso è richiesto per mostrare i contatti.</string>
-    <string name="contacts_subtext">Questo permesso è richiesto per aggiungere nuovi contatti.</string>
+    <string name="contacts_read_subtext">Autorizzazione necessaria per mostrare i contatti memorizzati nel dispositivo.</string>
+    <string name="contacts_subtext">Autorizzazione necessaria per aggiungere nuovi contatti.</string>
     <string name="crash">Oops!\nBaldPhone ha riscontrato un problema ed ora si riavvierà.</string>
-    <string name="current_time">Orario Attuale</string>
+    <string name="current_time">Orario attuale</string>
     <string name="custom">Personalizza</string>
     <string name="dark">Scuro</string>
-    <string name="delete">Cancella</string>
-    <string name="delete___">Cancella %s?</string>
-    <string name="delete_all_alarms">Cancella tutte le sveglie</string>
+    <string name="delete">Elimina</string>
+    <string name="delete___">Elimina %s?</string>
+    <string name="delete_all_alarms">Elimina tutti</string>
     <string name="dialer">Telefono</string>
     <string name="display_settings">Schermo</string>
     <string name="done">Fatto</string>
     <string name="down">Giù</string>
     <string name="edit">Modifica</string>
     <string name="email">Email:</string>
-    <string name="enable_notification_access">Permetti L\'accesso alle Notifiche</string>
-    <string name="enable_notification_access_subtext">Per cortesia permetti a BaldPhone di accedere alle notifiche.</string>
+    <string name="enable_notification_access">Accesso alle notifiche</string>
+    <string name="enable_notification_access_subtext">Per cortesia consenti a BaldPhone di accedere alle notifiche.</string>
     <string name="enter">Invio</string>
     <string name="enter_contact_or_phone_number">Inserisci il nome del contatto:</string>
     <string name="evening">Sera</string>
-    <string name="example_of_different_text_sizes">Esempio di differenti dimensioni di testo\nDovrebbe essere leggibile e non
-        esagerato.
-    </string>
-    <string name="external_storage_subtext">Questo permesso è richiesto affiché sia possibile salvare le immagini.</string>
-    <string name="feedback">Invia Feedback</string>
-    <string name="feedback_cannot_be_empty">Feedback non può essere vuoto!</string>
+    <string name="example_of_different_text_sizes">Esempio di testo in varie dimensioni. Scegli una impostazione per cui sia leggibile, ma non esagerato.</string>
+    <string name="external_storage_subtext">Autorizzazione necessaria per salvare le immagini.</string>
+    <string name="feedback">Invia feedback</string>
+    <string name="feedback_cannot_be_empty">Il feedback non può essere vuoto!</string>
     <string name="feedback_sent_successfully">Feedback inviato con successo!</string>
-    <string name="first_please_select_how_you_want_to_interact_with_buttons">Per favore scegli il livello di accessibilità
-    </string>
-    <string name="font_size">Carattere</string>
+    <string name="first_please_select_how_you_want_to_interact_with_buttons">Scegli il livello di accessibilità:</string>
+    <string name="font_size">Dimensioni carattere</string>
     <string name="friday">Venerdì</string>
-    <string name="have_hard_time_using_the_phone_s_keyboard_use_baldphone_s_big_keyboard_instead">È difficile utilizzare
-        la tastiera del telefono? Usa la GRANDE tastiera di BaldPhone!
-    </string>
+    <string name="have_hard_time_using_the_phone_s_keyboard_use_baldphone_s_big_keyboard_instead">È difficile utilizzare la tastiera del telefono? Usa la tastiera GRANDE di BaldPhone!</string>
     <string name="hello">Ciao</string>
     <string name="help">Aiuto</string>
     <string name="hide">Nascondi</string>
-    <string name="high_level">Alto Livello</string>
+    <string name="high_level">Alto</string>
     <string name="home_phone_number">Numero di telefono di casa</string>
     <string name="hour">Ora</string>
-    <string name="huge">Gigante</string>
+    <string name="huge">Molto grande</string>
     <string name="internet">Internet</string>
-    <string name="invoked_in">Citato in:</string>
+    <string name="invoked_in">Suona fra</string>
     <string name="it_s_highly_recommended_to_use_baldphone_s_home_screen_as_the_default_home_launcher">Un\'ultima
-        cosa:\nÈ altamente raccomandato utilizzare la home screen di Baldphone come launcher predefinito
-    </string>
+        cosa:\nsi consiglia vivamente di utilizzare BaldPhone come launcher (Home page) predefinito.</string>
     <string name="language">Lingua</string>
-    <string name="language_settings">Impostazioni della lingua</string>
+    <string name="language_settings">Lingua</string>
     <string name="large">Grande</string>
-    <string name="left_handed">Mancini</string>
-    <string name="light">Sottile</string>
-    <string name="location">Località</string>
-    <string name="emergency_services">Servizi d\'emergenza</string>
+    <string name="left_handed">Sinistra</string>
+    <string name="light">Chiaro</string>
+    <string name="location">Geolocalizzazione</string>
+    <string name="emergency_services">112 Numero di Emergenza</string>
     <string name="mail">Mail</string>
     <string name="maps">Mappe</string>
 
 
     <string name="medium">Medio</string>
-    <string name="medium_level">Medio Livello</string>
+    <string name="medium_level">Medio</string>
     <string name="message">Messaggio</string>
     <string name="messages">Messaggi</string>
     <string name="minute">Minuto</string>
@@ -183,18 +176,18 @@
     <string name="morning">Mattina</string>
     <string name="name">Nome</string>
     <string name="named__">chiamato</string>
-    <string name="new_alarm___was_created">È stato creato un nuovo allarme!</string>
+    <string name="new_alarm___was_created">Nuova sveglia %s impostata</string>
     <string name="nfc">NFC</string>
     <string name="no">No</string>
     <string name="notes">Note</string>
-    <string name="notes_settings">Impostazioni delle Note</string>
-    <string name="notes_settings_subtext">Scegli se vuoi la pagina delle Note sulla schermata principale.</string>
+    <string name="notes_settings">Pagina note</string>
+    <string name="notes_settings_subtext">Scegli se vuoi la pagina delle note insieme alla schermata principale.</string>
     <string name="notifications">Notifiche</string>
 
     <string name="of">di</string>
-    <string name="off">Off</string>
+    <string name="off">Non attivo</string>
     <string name="ok">OK</string>
-    <string name="on">On</string>
+    <string name="on">Attivo</string>
 
     <string name="only_once">Solo una</string>
 
@@ -202,80 +195,76 @@
     <string name="open">Apri</string>
 
     <string name="outgoing">In uscita</string>
-    <string name="page">Page</string>//pagina 1 di 2
-    <string name="permissions_part">Permessi</string>
-    <string name="personalization_settings">Personalizzazione</string>
+    <string name="page">Page</string> // Pagina 1 di 2
+    <string name="permissions_part">Autorizzazioni</string>
+    <string name="personalization_settings">Personalizza</string>
     <string name="phone">Telefono</string>
     <string name="photo">Foto</string>
-    <string name="photos">Fotografie</string>
-    <string name="pill_added">Pillola aggiunta!</string>
-    <string name="pill_name">Nome della Pillola</string>
+    <string name="photos">Galleria</string>
+    <string name="pill_added">Pillola aggiunta</string>
+    <string name="pill_name">Nome della pillola</string>
     <string name="pills">Pillole</string>
-    <string name="press_longer">Premi più a lungo!</string>
+    <string name="press_longer">Tocca più a lungo</string>
     <string name="timer">Timer</string>
-    <string name="read_call_log">Leggi Cronologia delle Chiamate</string>
-    <string name="read_call_log_subtext">Questo permesso è richiesto affinché sia possibile visualizzare la cronologia delle chiamate.</string>
-    <string name="read_contacts">Leggi contatti</string>
+    <string name="read_call_log">Lettura chiamate recenti</string>
+    <string name="read_call_log_subtext">Autorizzazione necessaria per mostrare l\'elenco delle chiamate recenti.</string>
+    <string name="read_contacts">Lettura contatti</string>
     <string name="received">Ricevuto</string>
-    <string name="recent">Recente</string>
-    <string name="regular_level">Livello Regolare</string>
+    <string name="recent">Chiamate</string> // Alternativa: Recenti
+    <string name="regular_level">Normale</string>
 
-    <string name="remove_from_favorite">Rimuovi dai Favoriti</string>
-    <string name="remove_from_home">Rimuovi dalla Schermata d\'avvio</string>
+    <string name="remove_from_favorite">Rimuovi dai preferiti</string>
+    <string name="remove_from_home">Rimuovi dalla schermata Home</string>
     <string name="remove_from_sos">Rimuovi da SOS</string>
     <string name="remove_shortcut">Rimuovi scorciatoia</string>
-    <string name="removed_all_alarms">Tutti le sveglie rimosse!</string>
+    <string name="removed_all_alarms">Tutte le sveglie sono stete eliminate</string>
     <string name="repeats_every_day">Ogni giorno</string>
-    <string name="right_handed">Per mano destra</string>
+    <string name="right_handed">Destra</string>
 
     <string name="saturday">Sabato</string>
-    <string name="save">salva</string>
+    <string name="save">Salva</string>
     <string name="send">Invia</string>
-    <string name="set_default_dialer">Imposta come App predefinita per la chiamata</string>
-    <string name="set_default_dialer_subtext">BaldPhone ha bisogno di essere impostata come app predefinita per la chiamata.</string>
-    <string name="set_home_screen">Imposta Schermata d\'avvio</string>
-    <string name="set_home_screen_subtext">Per utilizzare BaldPhone, dovresti impostarlo come schermata d\'avvio.\nÈ
-        reversibile e può essere cambiato dalle impostazioni.
-    </string>
-    <string name="set_keyboard">Imposta Tastiera</string>
-    <string name="setting_does_not_exist">Questa Impostazione Non Esiste</string>
+    <string name="set_default_dialer">Imposta come app predefinita per la chiamata</string>
+    <string name="set_default_dialer_subtext">BaldPhone ha bisogno di essere impostata come app predefinita per le chiamate.</string>
+    <string name="set_home_screen">Imposta Home page</string>
+    <string name="set_home_screen_subtext">Per utilizzare BaldPhone dovresti impostarlo come Home page. È una scelta che puoi sempre modificare da impostazioni avanzate.</string>
+    <string name="set_keyboard">Imposta tastiera</string>
+    <string name="setting_does_not_exist">Questa impostazione non esiste</string>
     <string name="settings">Impostazioni</string>
-    <string name="settings_permission">Impostazione dei Permessi</string>
+    <string name="settings_permission">Impostazione autorizzazioni</string>
     <string name="share">Condividi</string>
-    <string name="share_actual_text">Ciao, Sto usando questa piattaforma chiamata "BaldPhone" che sostituisce l\'interfaccia del telefono con una
-        più grande e facile da usare.\nTi interessa?\nPuoi scaricarla gratuitamente!\nguarda il link
-        sotto per altre informazioni:\n\nhttps://sites.google.com/view/baldphone
+    <string name="share_actual_text">Ciao, sto usando una app chiamata \"BaldPhone\" che sostituisce l\'interfaccia dello smartphone con una
+        più grande e facile da usare.\nTi interessa?\nPuoi scaricarla gratuitamente!\nGuarda questo link
+        per altre informazioni:\n\nhttps://sites.google.com/view/baldphone
     </string>
-    <string name="share_bald_phone_subtext">Hey, conosci qualcuno che vorrebbe saperne di più su BaldPhone?\nPuoi
-        condividerla con loro!"
-    </string>
+    <string name="share_bald_phone_subtext">Conosci qualcuno che potrebbe essere interessato a BaldPhone? Fagli sapere che esiste!</string>
     <string name="share_baldphone">Condividi BaldPhone</string>
-    <string name="share_contact">Condividi Contatto</string>
+    <string name="share_contact">Condividi contatto</string>
     <string name="share_differently">Condividi per mezzo di un\'altra app</string>
-    <string name="share_via_whatsapp">Condividi Via Whatsapp</string>
+    <string name="share_via_whatsapp">Condividi via WhatsApp</string>
     <string name="shift">sposta</string>
     <string name="show">Mostra</string>
     <string name="small">Piccolo</string>
-    <string name="snooze">dormita</string>
+    <string name="snooze">Più tardi</string>
     <string name="sos">SOS</string>
     <string name="sos_is_full">SOS è pieno!</string>
-    <string name="sos_is_full_subtext">SOS è pieno! Per favore rimuovi altri contatti SOS prima di aggiungerne un altro</string>
-    <string name="speak">Parla</string>
-    <string name="speech_to_text">Parla per Scrivere</string>
-    <string name="strong_hand">Mano Dominante</string>
-    <string name="strong_hand_subtext">Scegli la mano dominante per modificare l\'interfaccia utente.</string>
-    <string name="submit">sottoponi</string>
+    <string name="sos_is_full_subtext">La schermata emergenza è piena! Rimuovi uno dei contatti di emergenza per poterne aggiungere un altro.</string>
+    <string name="speak">Detta</string>
+    <string name="speech_to_text">Detta</string>
+    <string name="strong_hand">Mano preferita</string>
+    <string name="strong_hand_subtext">Scegli la mano preferita per impostare l\'interfaccia utente.</string>
+    <string name="submit">Imposta</string>
     <string name="sunday">Domenica</string>
-    <string name="technical_information">Informazioni Tecniche</string>
+    <string name="technical_information">Informazioni tecniche</string>
     <string name="theme_settings">Tema</string>
-    <string name="theme_settings_subtext">Scegli un tema</string>
+    <string name="theme_settings_subtext">Scegli un tema.</string>
 
     <string name="thursday">Giovedì</string>
-    <string name="time_changer">Modificatore per il tempo delle pillole</string>
+    <string name="time_changer">Modifica orario pillole</string>
     <string name="tiny">Piccolo</string>
-    <string name="to___days_and___hours_from_now">a %d giorni e %d ore da adesso</string>
-    <string name="to___hours_and___minutes_from_now">a %d ore e %d minuti da adesso</string>
-    <string name="to___minuets_from_now">a %d minuti da adesso</string>
+    <string name="to___days_and___hours_from_now">Suona fra %d giorni e %d ore</string>
+    <string name="to___hours_and___minutes_from_now">Suona fra %d ore e %d minuti</string>
+    <string name="to___minuets_from_now">Suona fra %d minuti</string>
     <string name="today">Oggi</string>
     <string name="took">Preso!</string>
     <string name="tuesday">Martedì</string>
@@ -283,86 +272,84 @@
     <string name="uninstall_subtext">Sei sicuro di voler cancellare %s?\n%s\le informazioni verranno cancellate per sempre!</string>
     <string name="up">Sopra</string>
     <string name="video">Video</string>
-    <string name="video_tutorials">Video Introduttivi</string>
+    <string name="video_tutorials">Video introduttivi</string>
     <string name="videos">Video</string>
 
-    <string name="voice_mail">Mail Vocale</string>
+    <string name="voice_mail">Messaggio vocale</string>
     <string name="wednesday">Mercoledì</string>
-    <string name="whatsapp">Whatsapp</string>
-    <string name="wifi">Wifi</string>
-    <string name="will_repeat_only_once">si ripeterà solo una volta!</string>
+    <string name="whatsapp">WhatsApp</string>
+    <string name="wifi">Wi-Fi</string>
+    <string name="will_repeat_only_once">Si ripete una sola volta.</string>
     <string name="write">Scrivi</string>
-    <string name="write_contacts">Scrivi Contatti</string>
-    <string name="write_external_storage">Scrivi memoria esterna</string>
+    <string name="write_contacts">Scrittura contatti</string>
+    <string name="write_external_storage">Accesso ai file sul dispositivo</string>
     <string name="yes">Sì</string>
     <string name="yesterday">Ieri</string>
-    <string name="nothing">Niente</string>
+    <string name="nothing">Nessun contenuto</string>
     <string name="no_contacts_found">Nessun contatto trovato!</string>
-    <string name="no_alarms">Nessuna Sveglia\nCreane una cliccando\n\"Aggiungi Sveglia\"\nOppure\n\"Aggiungi Timer\"</string>
-    <string name="no_pills">Nessuna Pillola\nCreane una cliccando\n\"Aggiungi Pillola\"</string>
-    <string name="clear_all_notifications">Elimina tutte le Notifiche</string>
-    <string name="clear_cache_subtext">Sei sicuro di voler eliminare la cache?\nAnche le scorciatoie per le App verranno rimosse!
+    <string name="no_alarms">Nessuna sveglia impostata.\nPuoi crearne una toccando \"Aggiungi sveglia\" oppure \"Aggiungi timer\".</string>
+    <string name="no_pills">Nessuna pillola definita.\nPuoi crearne una toccando \"Aggiungi pillola\".</string>
+    <string name="clear_all_notifications">Elimina tutte le notifiche</string>
+    <string name="clear_cache_subtext">Vuoi eliminare il contenuto della cache?\nEliminare i file temporanei può risolvere alcuni malfunzionamenti della app, ma verranno eliminate anche le scorciatoie create nella Home.
     </string>
-    <string name="permissions_calm">Ciao, BaldPhone deve avere i seguenti permessi per funzionare. Alcuni di questi
+    <string name="permissions_calm">Ciao, BaldPhone deve avere le seguenti autorizzazioni per funzionare. Alcuni di questi
         possono spaventarti, ma è l\'unico modo in cui BaldPhone può sostituire l\'interfaccia del telefono. Nessuna informazione viene presa e non causa
-        danni. Premi OK per fornire i permessi o premi no per uscire da BaldPhone.
+        danni. Premi OK per fornire le autorizzazioni o premi No per uscire da BaldPhone.
     </string>
-    <string name="pending_update">In attesa di Aggiornamento</string>
-    <string name="download">Scarica</string>
-    <string name="install_updates">Installa gli Aggiornamenti</string>
-    <string name="install_updates_subtext">Questo permesso è richiesto per permettere a BaldPhone di aggiornarsi</string>
+    <string name="pending_update">In attesa di aggiornamento</string>
+    <string name="download">Download</string>
+    <string name="install_updates">Installa gli aggiornamenti</string>
+    <string name="install_updates_subtext">Autorizzazione necessaria per l\'auto-aggiornamento di BaldPhone.</string>
     <string name="a_new_update_is_available">Un nuovo aggiornamento è disponibile!\nGli aggiornamenti sono importanti perché permettono a BaldPhone di funzionare
         senza problemi.\nPremi OK per scaricare.
     </string>
-    <string name="current_version">Versione Attuale:\n</string>
-    <string name="new_version">Nuova Versione:\n</string>
+    <string name="current_version">Versione attuale:\n</string>
+    <string name="new_version">Nuova versione:\n</string>
     <string name="new_updates_are_ready_to_be_downloaded">Nuovi aggiornamenti sono pronti per essere scaricati.</string>
     <string name="install">Installa</string>
-    <string name="data_warning">Avviso Dati</string>
-    <string name="data_warning_subtext">Ciao, non sei connesso al WIFI.\nLe dimensioni del download sono circa 3MB,
-        se sei all\'estero potrebbe costarti del credito.\nVuoi procedere con il Download?
+    <string name="data_warning">Avviso dati</string>
+    <string name="data_warning_subtext">Ciao, non sei connesso al Wi-Fi.\nLe dimensioni del download sono circa 3Mb,
+        se sei all\'estero potrebbe costarti del credito.\nVuoi procedere con il download?
     </string>
     <string name="update_message_is_corrupted">Il messaggio di aggiornamento è corrotto.</string>
-    <string name="check_for_updates">Controlla per aggiornamenti</string>
+    <string name="check_for_updates">Verifica aggiornamenti disponibili</string>
     <string name="could_not_connect_to_server">Impossibile connettersi al server!</string>
     <string name="could_not_connect_to_internet">Impossibile connettersi ad Internet!</string>
-    <string name="could_not_start_the_download">Impossibile cominciare il download!</string>
-    <string name="downloaded_update_file_could_not_be_deleted">Il file di aggiornamento non può essere cancellato!</string>
+    <string name="could_not_start_the_download">Impossibile iniziare il download!</string>
+    <string name="downloaded_update_file_could_not_be_deleted">Il file di aggiornamento non può essere eliminato!</string>
     <string name="downloading">Scaricamento in corso…</string>
 
-    <string name="baldphone_is_up_to_date">BaldPhone è aggiornato.</string>
+    <string name="baldphone_is_up_to_date">BaldPhone è aggiornato</string>
     <string name="what_s_new">Cosa c\'è di nuovo</string>
-    <string name="download_finished">Scaricamento terminato!</string>
-    <string name="downloading_updates">Scaricamento degli aggiornamenti…</string>
+    <string name="download_finished">Download completato</string>
+    <string name="downloading_updates">Download aggiornamenti…</string>
     <string name="installing_doesn_t_work">L\'installazione non funziona?</string>
     <string name="try_now">Prova Ora</string>
     <string name="download_progress">Progresso dello scaricamento</string>
     <string name="what_do_you_want_to_do_with___">Cosa vuoi fare con %s?</string>
-    <string name="crash_reports">Report di crash</string>
-    <string name="crash_reports_subtext">I report di crash servono a rendere l\'utilizzo di BaldPhone perfetto\nSono utilizzati soltanto
-        per riparare gli errori, e non viene presa alcuna informazione che non serve a risolvere il problema
-    </string>
-    <string name="custom_app">App Personalizzata</string>
-    <string name="custom_app_subtext">Scegli l\'app personalizzata che vuoi mettere sulla schermata principale.</string>
+    <string name="crash_reports">Segnalazione automatica errori</string>
+    <string name="crash_reports_subtext">La segnalazione automatica errori serve agli sviluppatori per migliorare il funzionamento di BaldPhone. Vengono raccolte e inviate solo le informazioni necessarie a risolvere il problema.</string>
+    <string name="custom_app">Personalizza app</string>
+    <string name="custom_app_subtext">Scegli l\'app che vuoi assegnare a questo pulsante nella schermata Home.</string>
     <string name="no_app_was_found">Non è stata trovata alcuna app corrispondente!</string>
     <string name="alarm">Sveglia</string>
     <string name="no_new_notifications">Nessuna nuova notifica</string>
-    <string name="sound">Suono</string>
-    <string name="mute">Muto</string>
+    <string name="sound">Normale</string>
+    <string name="mute">Silenzioso</string>
     <string name="vibrate">Vibrazione</string>
     <string name="your_phone_doesnt_have_assistant_installed">Il tuo telefono non ha alcun assistente installato.</string>
 
 
     <string name="status_bar_settings">Barra di stato</string>
-    <string name="status_bar_settings_subtext">Dove vuoi che venga mostrata la barra di stato?</string>
-    <string name="only_home_screen">Soltanto nella schermata principale</string>
-    <string name="nowhere">Da nessuna parte</string>
-    <string name="everywhere">Ovunque</string>
+    <string name="status_bar_settings_subtext">Quando vuoi che sia visibile la barra di stato Android?</string>
+    <string name="only_home_screen">Schermata Home</string>
+    <string name="nowhere">Mai</string>
+    <string name="everywhere">Sempre</string>
 
 
     <string name="share_photo">Condividi foto</string>
 
-    <string name="choose_language_for_keyboard">Scegli lingua</string>
+    <string name="choose_language_for_keyboard">Scegli la lingua</string>
     <string name="hebrew">Ebraico</string>
     <string name="english">Inglese</string>
 
@@ -371,36 +358,36 @@
     <string name="go">Vai</string>
 
 
-    <string name="dialer_sounds">Suoni di chiamata</string>
-    <string name="dialer_sounds_subtext">Scegli se vuoi avere i suoni di chiamata.</string>
-    <string name="low_battery_alert">Avviso per batteria scarica</string>
-    <string name="low_battery_alert_subtext">Scegli se vuoi che la barra di stato diventi rossa nella schermata principale quando la batteria è sotto il 20%\nNota Non verrà mostrata se la barra di stato è nascosta.</string>
+    <string name="dialer_sounds">Suoni tastierino</string>
+    <string name="dialer_sounds_subtext">Scegli se vuoi che il tastierino emetta dei suoni quando componi un numero di telefono.</string>
+    <string name="low_battery_alert">Avviso batteria scarica</string>
+    <string name="low_battery_alert_subtext">Scegli se vuoi che la barra di stato nella schermata Home diventi rossa quando la carica della batteria è inferiore al 20%.\nNon è visibile se la barra di stato è nascosta.</string>
 
-    <string name="also_available_at">È disponibile anche a\nbaldphone.contact@gmail.com\nFeedback devono essere in Inglese/Ebraico!</string>
-    <string name="grant_all_permissions">Dai tutti i permessi</string>
+    <string name="also_available_at">Puoi anche scrivere a\nbaldphone.contact@gmail.com\nPer cortesia, invia feedback solo in inglese o in ebraico.</string>
+    <string name="grant_all_permissions">Autorizzazioni richieste</string>
     <string name="donate">Dona</string>
-    <string name="emergency_button">Emergency Button</string>
-    <string name="emergency_settings_subtext">Choose if you want to have an Emergency Button on the home screen.</string>
+    <string name="emergency_button">Pulsante emergenza</string>
+    <string name="emergency_settings_subtext">Scegli se vuoi avere il pulsante emergenza nella schermata Home.</string>
     <string name="private_number">Private Number</string>
-    <string name="swipe_left_or_right">Swipe left or right</string>
-    <string name="press_next_or_back_buton">Press next or back arrow</string>
-    <string name="click_delay">Click Delay</string>
-    <string name="no_delay">No Delay</string>
-    <string name="scrolling">Scrolling</string>
-    <string name="arrows">Arrows</string>
-    <string name="swipe">Touch</string>
-    <string name="_long">Long</string>
-    <string name="_short">Short</string>
-    <string name="do_you_want_to_save_your_changes">Do you want to save your changes?</string>
-    <string name="discard">Discard</string>
-    <string name="no_recent_calls">No Recent Calls</string>
-    <string name="apps_sort_method">Apps Sort Method</string>
-    <string name="apps_sort_method_subtext">Choose whether you want to sort the apps in one grid or to have them divided into different groups via letters</string>
-    <string name="groups">Groups</string>
-    <string name="one_grid">One Grid</string>
+    <string name="swipe_left_or_right">Striscia verso sinistra o destra</string>
+    <string name="press_next_or_back_buton">Tocca la freccia destra o sinistra</string>
+    <string name="click_delay">Tocco</string>
+    <string name="no_delay">Immediato</string>
+    <string name="scrolling">Scorri</string>
+    <string name="arrows">Frecce</string>
+    <string name="swipe">Striscia</string>
+    <string name="_long">Lungo</string>
+    <string name="_short">Breve</string>
+    <string name="do_you_want_to_save_your_changes">Vuoi salvare le modifiche?</string>
+    <string name="discard">Ignora</string>
+    <string name="no_recent_calls">Nessuna chiamata recente</string>
+    <string name="apps_sort_method">Ordinamento app</string>
+    <string name="apps_sort_method_subtext">Scegli se vuoi vedere le app ordinate in una griglia o se le vuoi raggruppate per lettera.</string>
+    <string name="groups">Per lettera</string>
+    <string name="one_grid">Griglia</string>
     <string name="colorful">Colorful</string>
-    <string name="colorful_subtext">Do you want to make BaldPhone more colorful?</string>
-    <string name="edit_home_screen">Edit Home Screen</string>
+    <string name="colorful_subtext">Vuoi avere un BaldPhone più colorato?</string>
+    <string name="edit_home_screen">Modifica schermata Home</string>
 
 
 </resources>

--- a/manual/how_to_build_on_debian_linux.md
+++ b/manual/how_to_build_on_debian_linux.md
@@ -1,0 +1,180 @@
+# How to compile BaldPhone APK from sources, on Debian GNU/Linux
+
+The **BaldPhone** app uses the **Gradle** building tool, this 
+means that all the packages required to compile it, can be 
+automatically downloaded and installed by the user, without 
+requiring to install system packages. This should solve also the 
+problem of Debian, shipping rather outdated versions of the 
+various tools. Here we tested everything on a **Debian 10 
+Stretch**.  Install the **git** and the **OpenJDK** Java runtime 
+packages:
+
+```
+apt-get install git openjdk-11-jre openjdk-11-jre-headless
+```
+
+You shouldn't need to install other Debian packages. E.g. the 
+following are NOT required: android-sdk-platform-23, gradle.
+
+Clone the BaldPhone source code tree on your disk:
+
+```
+git clone https://github.com/UriahShaulMandel/BaldPhone.git
+```
+
+This will create the BaldPhone directory, constaining about 230 
+Mb of data.
+
+Create a directory where the Gradle building system will 
+download and install all the required stuff to compile the 
+Android package. The $HOME environment variable should point to 
+your home directory (e.g. /home/johndoe). The environment 
+variable **ANDROID_HOME** must be set whenever you will run the 
+building tool again:
+
+```
+mkdir -p $HOME/lib/android-sdk
+export ANDROID_HOME=$HOME/lib/android-sdk
+```
+
+Now you have to accept the **Android SDK licenses**. Accepting 
+the licenses merely means that you have to put some files into 
+the $HOME/lib/android-sdk/licenses/ directory. Fortunately 
+enough, that files can be downloaded from the net:
+
+```
+mkdir -p $HOME/lib/android-sdk/licenses
+git clone https://github.com/Shadowstyler/android-sdk-licenses.git
+cp -a android-sdk-licenses/*-license $HOME/lib/android-sdk/licenses
+```
+
+Start now a first build run:
+
+```
+cd BaldPhone
+chmod 755 gradlew
+./gradlew
+```
+
+This will start a procedure which downloads all the required 
+packages, e.g. the new gradle-5.4.1-all.zip, various Java 
+libraries, etc. Everything will be installed under the 
+$HOME/.gradle/ directory. This will occupy several thousands 
+megabytes (about 500 Mb in my case). You shoul obtain the 
+**BUILD SUCCESSFUL** message.
+
+You can now try to actually build the APK package, with:
+
+```
+./gradlew build
+```
+
+This will download other tons of software under the 
+$HOME/lib/android-sdk/ directory: Android SDK Build-Tools, 
+Platform-Tools, etc. In my case about 330 Mb of software was 
+installed. The procedure will install current versions of that 
+tools, this is why we did not installed the (rather outdated) 
+Debian packages, eg. android-sdk-platform-23. You shoul obtain 
+the following result:
+
+```
+BUILD SUCCESSFUL in 20m 0s
+```
+
+The new **APK package** should exists in this path:
+
+```
+./app/build/outputs/apk/baldUpdates/release/app-baldUpdates-release-unsigned.apk
+```
+
+Beware of the **"unisgned"** label! This means that you will be 
+UNABLE TO INSTALL IT on you smartphone! You should pretend to 
+have a valid developer signature and use it to **sign the 
+package**. So do the following (eventually replace the name 
+johndoe with your name):
+
+```
+cd $HOME
+keytool -genkey -v -keystore johndoe.keystore -alias johndoe -keyalg RSA -keysize 2048 -validity 10000
+```
+
+You have to type a password and some info:
+
+```
+Enter keystore password: MySecret
+What is your first and last name? John Doe
+What is the name of your organizational unit? Android Developer
+What is the name of your organization? JohnDoe.Org
+What is the name of your City or Locality? Florence
+What is the name of your State or Province? Italy
+What is the two-letter country code for this unit? IT
+```
+
+Now edit the file **$HOME/.gradle/gradle.properties** and write 
+something like this:
+
+```
+MYAPP_RELEASE_STORE_FILE=/home/johndoe/johndoe.keystore
+MYAPP_RELEASE_KEY_ALIAS=johndoe
+MYAPP_RELEASE_STORE_PASSWORD=MySecret
+MYAPP_RELEASE_KEY_PASSWORD=MySecret
+```
+
+Don't forget to protect the file, because it contains your password:
+
+```
+chmod 640 $HOME/.gradle/gradle.properties
+```
+
+Update your build recipe editing the **app/build.gradle** file:
+
+```
+cd BaldPhone/
+vi app/build.gradle
+```
+
+You should add a **signingConfigs** section and a **buildTypes 
+release** line:
+
+```
+android {
+    ...
+    defaultConfig {
+        ...
+    }
+    signingConfigs {
+        release {
+            if (project.hasProperty('MYAPP_RELEASE_STORE_FILE')) {
+                storeFile file(MYAPP_RELEASE_STORE_FILE)
+                storePassword MYAPP_RELEASE_STORE_PASSWORD
+                keyAlias MYAPP_RELEASE_KEY_ALIAS
+                keyPassword MYAPP_RELEASE_KEY_PASSWORD
+            }
+        }
+    }
+
+    buildTypes {
+        release {
+            ...
+            signingConfig signingConfigs.release
+        }
+    }
+```
+
+Finally you can repeat the build:
+
+```
+./gradlew build
+```
+
+The result should be this APK file:
+
+```
+./app/build/outputs/apk/baldUpdates/release/app-baldUpdates-release.apk
+```
+
+Copy this file on your smartphone and install it!
+
+If you modify something into the source tree, you have to repeat 
+only the **./gradlew build** step to obtain a new apk file. 
+Never forget to export the **ANDROID_HOME** variable.


### PR DESCRIPTION
## Purpose
I refactored the Italian translation, because it was not very consistent with Android guidelines and GUI interface. Now all the items are named like in the Android interface (e.g. Settings is Impostazioni, Favourites is Preferiti, etc.). Actions like Delete and Cancel are consistently translated into Elimina and Annulla (avoiding the Italian confusion word Cancella), etc.
Strings were extensively verified into the user interface, to check that labels fits well in buttons, etc.
All the strings are now translated.

## Approach
To check the Italian translation I had to learn how to compile a new APK package from the sources, so I added the bonus of a Build HOW-TO for Debian GNU/Linux.
